### PR TITLE
Stop baking IPA into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ RUN yum install -y python-requests && \
     yum install -y openstack-ironic-api openstack-ironic-conductor rabbitmq-server crudini iproute dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs && \
     yum clean all
 
-RUN mkdir -p /var/www/html/images && \
-    curl https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar | tar -C /var/www/html/images/ -xf -
-
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/
 


### PR DESCRIPTION
We now bind mount it in, so it can be downloaded once
and reused, which should make the image a lot smaller.