### PR TITLE
Add self configuration to Ironic for Openshift Baremetal Operator.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig && \
     crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template && \
     ironic-dbsync --config-file /etc/ironic/ironic.conf create_schema
 
+COPY ./config /config
 COPY ./runironic.sh /bin/runironic
 COPY ./runhealthcheck.sh /bin/runhealthcheck
 

--- a/config/configure_ironic.sh
+++ b/config/configure_ironic.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -xe
+
+# Configure dnsmasq and pxe boot parameters.
+
+IRONIC_IP=${IRONIC_IP:-"172.22.0.1"}
+IRONIC_DHCP_RANGE=${IRONIC_DHCP_RANGE:-"172.22.0.10,172.22.0.100"}
+
+cat /config/dnsmasq.conf | sed -e s/IRONIC_IP/$IRONIC_IP/g -e s/IRONIC_DHCP_RANGE/$IRONIC_DHCP_RANGE/g > /etc/dnsmasq.conf
+cat /config/dualboot.ipxe | sed s/IRONIC_IP/$IRONIC_IP/g > /var/www/html/dualboot.ipxe
+cat /config/inspector.ipxe | sed s/IRONIC_IP/$IRONIC_IP/g > /var/www/html/inspector.ipxe
+
+# Add firewall rules to ensure the IPA ramdisk can reach Ironic and Inspector APIs on the host
+for port in 5050 6385 ; do
+    if ! iptables -C INPUT -i provisioning -p tcp -m tcp --dport $port -j ACCEPT > /dev/null 2>&1; then
+        iptables -I INPUT -i provisioning -p tcp -m tcp --dport $port -j ACCEPT
+    fi
+done
+
+# Get the images we need to serve.
+mkdir -p /var/www/html/images
+pushd /var/www/html/images
+
+export RHCOS_IMAGE_URL=${RHCOS_IMAGE_URL:-"https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/"}
+export RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.284}"
+export RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
+export RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-qemu.qcow2"
+export RHCOS_IMAGE_FILENAME_OPENSTACK="${RHCOS_IMAGE_NAME}-openstack.qcow2"
+
+# This is the one we actually want to use, but I'm not going to assemble it here
+# in a kubernetes managed container.
+export RHCOS_IMAGE_FILENAME_DUALDHCP="${RHCOS_IMAGE_NAME}-dualdhcp.qcow2"
+export RHCOS_IMAGE_FILENAME_LATEST="redhat-coreos-maipo-latest.qcow2"
+
+curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME_OPENSTACK}".gz
+curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar | tar -xf -
+
+if [ ! -e "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum" -o \
+     "$RHCOS_IMAGE_FILENAME_OPENSTACK" -nt "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum" ] ; then
+    md5sum "$RHCOS_IMAGE_FILENAME_OPENSTACK" | cut -f 1 -d " " > "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum"
+fi
+
+ln -sf "$RHCOS_IMAGE_FILENAME_OPENSTACK" "$RHCOS_IMAGE_FILENAME_LATEST"
+ln -sf "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum" "$RHCOS_IMAGE_FILENAME_LATEST.md5sum"
+popd
+

--- a/config/dnsmasq.conf
+++ b/config/dnsmasq.conf
@@ -1,0 +1,24 @@
+interface=provisioning
+except-interface=lo
+bind-dynamic
+dhcp-range=IRONIC_DHCP_RANGE
+enable-tftp
+tftp-root=/tftpboot
+
+dhcp-match=ipxe,175
+# Client is already running iPXE; move to next stage of chainloading
+dhcp-boot=tag:ipxe,http://IRONIC_IP:5280/dualboot.ipxe
+
+# Note: Need to test EFI booting
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+dhcp-match=set:efi,option:client-arch,11
+# Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
+dhcp-boot=tag:efi,tag:!ipxe,ipxe.efi
+
+# Client is running PXE over BIOS; send BIOS version of iPXE chainloader
+dhcp-boot=/undionly.kpxe,IRONIC_IP
+
+# Disable DHCP and DNS over provisioning network
+dhcp-option=3
+dhcp-option=6

--- a/config/dualboot.ipxe
+++ b/config/dualboot.ipxe
@@ -1,0 +1,22 @@
+#!ipxe
+
+# NOTE(lucasagomes): Loop over all network devices and boot from
+# the first one capable of booting. For more information see:
+# https://bugs.launchpad.net/ironic/+bug/1504482
+set netid:int32 -1
+:loop
+inc netid 
+isset ${net${netid}/mac} || chain pxelinux.cfg/${mac:hexhyp} || goto inspector 
+echo Attempting to boot from MAC ${net${netid}/mac:hexhyp}
+chain pxelinux.cfg/${net${netid}/mac:hexhyp} || goto loop 
+
+# If no networks configured to boot then introspect first valid one
+:inspector
+chain inspector.ipxe || goto loop_done
+
+:loop_done
+echo PXE boot failed! No configuration found for any of the present NICs
+echo and could not find inspector.ipxe to use as fallback.
+echo Press any key to reboot...
+prompt --timeout 180
+reboot

--- a/config/inspector.ipxe
+++ b/config/inspector.ipxe
@@ -1,0 +1,9 @@
+#!ipxe
+
+
+:retry_boot
+echo In inspector.ipxe
+imgfree
+kernel --timeout 60000 http://IRONIC_IP:5280/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+initrd --timeout 60000 http://IRONIC_IP:5280/images/ironic-python-agent.initramfs || goto retry_boot
+boot

--- a/configure_ironic.sh
+++ b/configure_ironic.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -xe
+
+# Configure dnsmasq and pxe boot parameters.
+
+IRONIC_IP=${IRONIC_IP:-"172.22.0.1"}
+IRONIC_DHCP_RANGE=${IRONIC_DHCP_RANGE:-"172.22.0.10,172.22.0.100"}
+
+cat /config/dnsmasq.conf | sed -e s/IRONIC_IP/$IRONIC_IP/g -e s/IRONIC_DHCP_RANGE/$IRONIC_DHCP_RANGE/g > /etc/dnsmasq.conf
+cat /config/dualboot.ipxe | sed s/IRONIC_IP/$IRONIC_IP/g > /var/www/html/dualboot.ipxe
+cat /config/inspector.ipxe | sed s/IRONIC_IP/$IRONIC_IP/g > /var/www/html/inspector.ipxe
+
+# Add firewall rules to ensure the IPA ramdisk can reach Ironic and Inspector APIs on the host
+# I suspect for kubernetes we can just use hostPort with hostNetwork.
+for port in 5050 6385 ; do
+    if ! iptables -C INPUT -i provisioning -p tcp -m tcp --dport $port -j ACCEPT > /dev/null 2>&1; then
+        iptables -I INPUT -i provisioning -p tcp -m tcp --dport $port -j ACCEPT
+    fi
+done
+
+# Get the images we need to serve.
+mkdir -p /var/www/html/images
+pushd /var/www/html/images
+
+export RHCOS_IMAGE_URL=${RHCOS_IMAGE_URL:-"https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/"}
+export RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.284}"
+export RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
+export RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-qemu.qcow2"
+export RHCOS_IMAGE_FILENAME_OPENSTACK="${RHCOS_IMAGE_NAME}-openstack.qcow2"
+
+# This is the one we actually want to use, but I'm not going to assemble it here
+# in a kubernetes managed container.
+export RHCOS_IMAGE_FILENAME_DUALDHCP="${RHCOS_IMAGE_NAME}-dualdhcp.qcow2"
+export RHCOS_IMAGE_FILENAME_LATEST="redhat-coreos-maipo-latest.qcow2"
+
+curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME_OPENSTACK}".gz
+curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar | tar -xf -
+
+if [ ! -e "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum" -o \
+     "$RHCOS_IMAGE_FILENAME_OPENSTACK" -nt "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum" ] ; then
+    md5sum "$RHCOS_IMAGE_FILENAME_OPENSTACK" | cut -f 1 -d " " > "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum"
+fi
+
+ln -sf "$RHCOS_IMAGE_FILENAME_OPENSTACK" "$RHCOS_IMAGE_FILENAME_LATEST"
+ln -sf "$RHCOS_IMAGE_FILENAME_OPENSTACK.md5sum" "$RHCOS_IMAGE_FILENAME_LATEST.md5sum"
+popd
+

--- a/runironic.sh
+++ b/runironic.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/bash
+
+set -x
+
+# Optionally configure ironic if the environment variable is set.
+if [ ! -e "$CONFIGURE_IRONIC" ] ; then
+    /config/configure_ironic.sh
+fi
+
 /usr/bin/python2 /usr/bin/ironic-conductor > /var/log/ironic-conductor.out 2>&1 &
 /usr/bin/python2 /usr/bin/ironic-api > /var/log/ironic-api.out 2>&1 &
 /usr/sbin/httpd > /var/log/httpd.out 2>&1 &
 /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf > /var/log/dnsmasq.out 2>&1 &
 /bin/runhealthcheck &
 sleep infinity
-


### PR DESCRIPTION
We're planning to run these containers along side the BMO deployment.
This means we need to configure Ironic at startup, along with any
images needed etc.  We still need the dualboot image in here but
we are much more limited running in a kubernetes pod than with podman
on the local host.