### PR TITLE
Changes to split up Ironic container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,16 +31,20 @@ RUN cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig && \
     crudini --set /etc/ironic/ironic.conf conductor automated_clean false && \
     crudini --set /etc/ironic/ironic.conf conductor api_url http://172.22.0.1:6385 && \
     crudini --set /etc/ironic/ironic.conf deploy http_url http://172.22.0.1 && \
-    crudini --set /etc/ironic/ironic.conf deploy http_root /var/www/html/ && \
+    crudini --set /etc/ironic/ironic.conf deploy http_root /shared/html/ && \
     crudini --set /etc/ironic/ironic.conf deploy default_boot_option local && \
     crudini --set /etc/ironic/ironic.conf inspector endpoint_override http://172.22.0.1:5050 && \
     crudini --set /etc/ironic/ironic.conf pxe ipxe_enabled true && \
+    crudini --set /etc/ironic/ironic.conf pxe tftp_root /shared/tftpboot && \
+    crudini --set /etc/ironic/ironic.conf pxe tftp_master_path /shared/tftpboot && \
+    crudini --set /etc/ironic/ironic.conf pxe instance_master_path /shared/html/master_images && \
+    crudini --set /etc/ironic/ironic.conf pxe images_path /shared/html/tmp && \
     crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template && \
     ironic-dbsync --config-file /etc/ironic/ironic.conf create_schema
 
 COPY ./runironic.sh /bin/runironic
+COPY ./rundnsmasq.sh /bin/rundnsmasq
+COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runhealthcheck.sh /bin/runhealthcheck
-
-RUN chmod +x /bin/runironic
 
 ENTRYPOINT ["/bin/runironic"]

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+cp /shared/dnsmasq.conf /etc/dnsmasq.conf
+cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /shared/tftpboot
+
+/usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf &
+/bin/runhealthcheck "dnsmasq" &>/dev/null &
+sleep infinity
+

--- a/runhealthcheck.sh
+++ b/runhealthcheck.sh
@@ -7,14 +7,18 @@ function killcontainer(){
 }
 
 while true ; do
-    sleep 10
+    sleep 30
 
-    HTTPDPID=$(pidof -s httpd)
-    fuser 80/tcp |& grep -w "$HTTPDPID"
+    if [ $1 = "httpd" ] ; then
+       HTTPDPID=$(pidof -s httpd)
+       fuser 80/tcp |& grep -w "$HTTPDPID"
 
-    DNSMASQPID=$(pidof dnsmasq)
-    fuser 69/udp |& grep -w "$DNSMASQPID"
+    elif [ $1 = "dnsmasq" ] ; then
+       DNSMASQPID=$(pidof dnsmasq)
+       fuser 67/udp |& grep -w "$DNSMASQPID"
 
-    curl -s http://172.22.0.1:6385 > /dev/null || ( echo "Can't contact ironic-api" && exit 1 )
+    elif [ $1 = "ironic" ] ; then
+       curl -s http://localhost:6385 > /dev/null || ( echo "Can't contact ironic-api" && exit 1 )
+    fi
 
 done

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+rmdir /var/www/html
+ln -s /shared/html/ /var/www/html
+
+/usr/sbin/httpd &
+/bin/runhealthcheck "httpd" &2>/dev/null &
+sleep infinity
+

--- a/runironic.sh
+++ b/runironic.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/bash
 /usr/bin/python2 /usr/bin/ironic-conductor > /var/log/ironic-conductor.out 2>&1 &
 /usr/bin/python2 /usr/bin/ironic-api > /var/log/ironic-api.out 2>&1 &
-/usr/sbin/httpd > /var/log/httpd.out 2>&1 &
-/usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf > /var/log/dnsmasq.out 2>&1 &
-/bin/runhealthcheck &
+/bin/runhealthcheck "ironic" &>/dev/null &
 sleep infinity
 


### PR DESCRIPTION
Allows Ironic container to be split between ironic, dnsmasq, and httpd
containers using this same image.