### PR TITLE
Provide overrides of Ironic provisioning IP, http port, and dnsmasq r…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /var/lib/ironic && \
 
 RUN cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig && \
     crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy noauth && \
-    crudini --set /etc/ironic/ironic.conf DEFAULT my_ip 172.22.0.1 && \
+    crudini --set /etc/ironic/ironic.conf DEFAULT my_ip IRONIC_IP && \
     crudini --set /etc/ironic/ironic.conf DEFAULT debug true && \
     crudini --set /etc/ironic/ironic.conf DEFAULT default_network_interface noop && \
     crudini --set /etc/ironic/ironic.conf DEFAULT enabled_boot_interfaces pxe,ipxe && \
@@ -29,11 +29,11 @@ RUN cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig && \
     crudini --set /etc/ironic/ironic.conf database connection sqlite:///var/lib/ironic/ironic.db && \
     crudini --set /etc/ironic/ironic.conf dhcp dhcp_provider none && \
     crudini --set /etc/ironic/ironic.conf conductor automated_clean false && \
-    crudini --set /etc/ironic/ironic.conf conductor api_url http://172.22.0.1:6385 && \
-    crudini --set /etc/ironic/ironic.conf deploy http_url http://172.22.0.1 && \
+    crudini --set /etc/ironic/ironic.conf conductor api_url http://IRONIC_IP:6385 && \
+    crudini --set /etc/ironic/ironic.conf deploy http_url http://IRONIC_IP:HTTP_PORT && \
     crudini --set /etc/ironic/ironic.conf deploy http_root /shared/html/ && \
     crudini --set /etc/ironic/ironic.conf deploy default_boot_option local && \
-    crudini --set /etc/ironic/ironic.conf inspector endpoint_override http://172.22.0.1:5050 && \
+    crudini --set /etc/ironic/ironic.conf inspector endpoint_override http://IRONIC_IP:5050 && \
     crudini --set /etc/ironic/ironic.conf pxe ipxe_enabled true && \
     crudini --set /etc/ironic/ironic.conf pxe tftp_root /shared/tftpboot && \
     crudini --set /etc/ironic/ironic.conf pxe tftp_master_path /shared/tftpboot && \
@@ -46,5 +46,9 @@ COPY ./runironic.sh /bin/runironic
 COPY ./rundnsmasq.sh /bin/rundnsmasq
 COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runhealthcheck.sh /bin/runhealthcheck
+
+COPY ./dnsmasq.conf /etc/dnsmasq.conf
+COPY ./inspector.ipxe /tmp/inspector.ipxe
+COPY ./dualboot.ipxe /tmp/dualboot.ipxe
 
 ENTRYPOINT ["/bin/runironic"]

--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -1,0 +1,24 @@
+interface=INTERFACE
+except-interface=lo
+bind-dynamic
+dhcp-range=DHCP_RANGE
+enable-tftp
+tftp-root=/shared/tftpboot
+
+dhcp-match=ipxe,175
+# Client is already running iPXE; move to next stage of chainloading
+dhcp-boot=tag:ipxe,http://IRONIC_IP:HTTP_PORT/dualboot.ipxe
+
+# Note: Need to test EFI booting
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+dhcp-match=set:efi,option:client-arch,11
+# Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
+dhcp-boot=tag:efi,tag:!ipxe,ipxe.efi
+
+# Client is running PXE over BIOS; send BIOS version of iPXE chainloader
+dhcp-boot=/undionly.kpxe,IRONIC_IP
+
+# Disable DHCP and DNS over provisioning network
+dhcp-option=3
+dhcp-option=6

--- a/dualboot.ipxe
+++ b/dualboot.ipxe
@@ -1,0 +1,22 @@
+#!ipxe
+
+# NOTE(lucasagomes): Loop over all network devices and boot from
+# the first one capable of booting. For more information see:
+# https://bugs.launchpad.net/ironic/+bug/1504482
+set netid:int32 -1
+:loop
+inc netid 
+isset ${net${netid}/mac} || chain pxelinux.cfg/${mac:hexhyp} || goto inspector 
+echo Attempting to boot from MAC ${net${netid}/mac:hexhyp}
+chain pxelinux.cfg/${net${netid}/mac:hexhyp} || goto loop 
+
+# If no networks configured to boot then introspect first valid one
+:inspector
+chain inspector.ipxe || goto loop_done
+
+:loop_done
+echo PXE boot failed! No configuration found for any of the present NICs
+echo and could not find inspector.ipxe to use as fallback.
+echo Press any key to reboot...
+prompt --timeout 180
+reboot

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -1,0 +1,9 @@
+#!ipxe
+
+
+:retry_boot
+echo In inspector.ipxe
+imgfree
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
+boot

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/bash
 
-cp /shared/dnsmasq.conf /etc/dnsmasq.conf
+IP=${IP:-"172.22.0.1"}
+HTTP_PORT=${HTTP_PORT:-"80"}
+DHCP_RANGE=${DHCP_RANGE:-"172.22.0.10,172.22.0.100"}
+INTERFACE=${INTERFACE:-"provisioning"}
+
+# Copy files to shared mount
+cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
+cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
 cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /shared/tftpboot
+
+# Use configured values
+sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g \
+       -e s/DHCP_RANGE/$DHCP_RANGE/g -e s/INTERFACE/$INTERFACE/g /etc/dnsmasq.conf
+sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g /shared/html/inspector.ipxe 
 
 /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf &
 /bin/runhealthcheck "dnsmasq" &>/dev/null &

--- a/runhealthcheck.sh
+++ b/runhealthcheck.sh
@@ -11,7 +11,7 @@ while true ; do
 
     if [ $1 = "httpd" ] ; then
        HTTPDPID=$(pidof -s httpd)
-       fuser 80/tcp |& grep -w "$HTTPDPID"
+       fuser $2/tcp |& grep -w "$HTTPDPID"
 
     elif [ $1 = "dnsmasq" ] ; then
        DNSMASQPID=$(pidof dnsmasq)

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/bash
 
+HTTP_PORT=${HTTP_PORT:-"80"}
+
 rmdir /var/www/html
 ln -s /shared/html/ /var/www/html
 
+sed -i 's/^Listen .*$/Listen '"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
+
+# Allow external access
+if ! iptables -C INPUT -p tcp --dport $HTTP_PORT -j ACCEPT 2>/dev/null ; then
+    iptables -I INPUT -p tcp --dport $HTTP_PORT -j ACCEPT
+fi
+
 /usr/sbin/httpd &
-/bin/runhealthcheck "httpd" &2>/dev/null &
+
+/bin/runhealthcheck "httpd" $HTTP_PORT &>/dev/null &
 sleep infinity
 

--- a/runironic.sh
+++ b/runironic.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/bash
+
+IP=${IP:-"172.22.0.1"}
+HTTP_PORT=${HTTP_PORT:-"80"}
+INTERFACE=${INTERFACE:-"provisioning"}
+
+sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g /etc/ironic/ironic.conf 
+
+# Allow access to Ironic
+if ! iptables -C INPUT -i $INTERFACE -p tcp -m tcp --dport 5050 -j ACCEPT > /dev/null 2>&1; then
+    iptables -I INPUT -i $INTERFACE -p tcp -m tcp --dport 5050 -j ACCEPT
+fi
+
 /usr/bin/python2 /usr/bin/ironic-conductor > /var/log/ironic-conductor.out 2>&1 &
+
 /usr/bin/python2 /usr/bin/ironic-api > /var/log/ironic-api.out 2>&1 &
 /bin/runhealthcheck "ironic" &>/dev/null &
 sleep infinity


### PR DESCRIPTION
…ange

Allow for overrides using environment variables of Ironic configuration.
The folowing environment variables are accepted:
  IP - provisioning interface IP address (default 172.22.0.1)
  HTTP_PORT - port used by http server (default 80)
  DHCP_RANGE - dhcp range to use for provisioning
       (default 172.22.0.10-172.22.0.100