### PR TITLE
Allow to exclude listen interfaces for dnsmasq.

### DIFF
--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -1,5 +1,4 @@
 interface=INTERFACE
-except-interface=lo
 bind-dynamic
 dhcp-range=DHCP_RANGE
 enable-tftp

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -4,6 +4,7 @@ IP=${IP:-"172.22.0.1"}
 HTTP_PORT=${HTTP_PORT:-"80"}
 DHCP_RANGE=${DHCP_RANGE:-"172.22.0.10,172.22.0.100"}
 INTERFACE=${INTERFACE:-"provisioning"}
+EXCEPT_INTERFACE=${EXCEPT_INTERFACE:-"lo"}
 
 mkdir -p /shared/html
 mkdir -p /shared/tftpboot
@@ -17,6 +18,9 @@ cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /shared/tftpboot
 sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g \
        -e s/DHCP_RANGE/$DHCP_RANGE/g -e s/INTERFACE/$INTERFACE/g /etc/dnsmasq.conf
 sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g /shared/html/inspector.ipxe 
+for iface in $( echo $EXCEPT_INTERFACE | tr ',' ' '); do
+    sed -i -e "/^interface=.*/ a\except-interface=$iface" /etc/dnsmasq.conf
+done
 
 /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf &
 /bin/runhealthcheck "dnsmasq" &>/dev/null &


### PR DESCRIPTION
When running dnsmasq on master nodes we don't want to run DHCP
server on a 'production' network with an external DHCP server.
To specify interfaces that have to be excluded specify them as
a comma separated list, for e.g.:
  EXCEPT_INTERFACE="lo,em1,enp12s0"