### PR TITLE
Configure HTTPd related directory within runhttpd.sh

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -6,18 +6,14 @@ DHCP_RANGE=${DHCP_RANGE:-"172.22.0.10,172.22.0.100"}
 INTERFACE=${INTERFACE:-"provisioning"}
 EXCEPT_INTERFACE=${EXCEPT_INTERFACE:-"lo"}
 
-mkdir -p /shared/html
 mkdir -p /shared/tftpboot
 
 # Copy files to shared mount
-cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
-cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
 cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /shared/tftpboot
 
 # Use configured values
 sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g \
        -e s/DHCP_RANGE/$DHCP_RANGE/g -e s/INTERFACE/$INTERFACE/g /etc/dnsmasq.conf
-sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g /shared/html/inspector.ipxe 
 for iface in $( echo $EXCEPT_INTERFACE | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=$iface" /etc/dnsmasq.conf
 done

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/bash
 
+IP=${IP:-"172.22.0.1"}
 HTTP_PORT=${HTTP_PORT:-"80"}
 
-rmdir /var/www/html
-ln -s /shared/html/ /var/www/html
+mkdir -p /shared/html
+chmod 0777 /shared/html
+
+# Copy files to shared mount
+cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
+cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
+
+# Use configured values
+sed -i -e s/IRONIC_IP/$IP/g -e s/HTTP_PORT/$HTTP_PORT/g /shared/html/inspector.ipxe
 
 sed -i 's/^Listen .*$/Listen '"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
+sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
+    -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
+    -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf
 
 # Allow external access
 if ! iptables -C INPUT -p tcp --dport $HTTP_PORT -j ACCEPT 2>/dev/null ; then


### PR DESCRIPTION
Attempt to run standalone ironic-httpd container fails:
  AH00526: Syntax error on line 119 of /etc/httpd/conf/httpd.conf:
  DocumentRoot '/var/www/html' is not a directory, or is not readable
  /bin/runhttpd: line 18:    12 Killed                 sleep infinity

So it makes sense to prepare httpd's files/dirs within /bin/runhttpd
script rather than in /bin/rundnsmasq.