### PR TITLE
Store Ironic container logs in shared mount

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -7,6 +7,7 @@ INTERFACE=${INTERFACE:-"provisioning"}
 EXCEPT_INTERFACE=${EXCEPT_INTERFACE:-"lo"}
 
 mkdir -p /shared/tftpboot
+mkdir -p /shared/log/dnsmasq
 
 # Copy files to shared mount
 cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /shared/tftpboot
@@ -18,7 +19,7 @@ for iface in $( echo $EXCEPT_INTERFACE | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=$iface" /etc/dnsmasq.conf
 done
 
-/usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf &
+/usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf 2>&1 | tee /shared/log/dnsmasq/dnsmasq.log &
 /bin/runhealthcheck "dnsmasq" &>/dev/null &
 sleep infinity
 

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -18,6 +18,17 @@ sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
     -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
     -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf
 
+# Remove log files from last deployment
+rm -rf /shared/log/httpd
+   
+mkdir -p /shared/log/httpd
+
+# Make logs available in shared mount
+touch /shared/log/httpd/access_log
+ln -s /shared/log/httpd/access_log /var/log/httpd/access_log
+touch /shared/log/httpd/error_log
+ln -s /shared/log/httpd/error_log /var/log/httpd/error_log
+
 # Allow external access
 if ! iptables -C INPUT -p tcp --dport $HTTP_PORT -j ACCEPT 2>/dev/null ; then
     iptables -I INPUT -p tcp --dport $HTTP_PORT -j ACCEPT

--- a/runironic.sh
+++ b/runironic.sh
@@ -15,7 +15,7 @@ cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 
 crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy noauth
 crudini --set /etc/ironic/ironic.conf DEFAULT my_ip ${IP}
-crudini --set /etc/ironic/ironic.conf DEFAULT debug true
+crudini --set /etc/ironic/ironic.conf DEFAULT debug true 
 crudini --set /etc/ironic/ironic.conf DEFAULT default_network_interface noop
 crudini --set /etc/ironic/ironic.conf DEFAULT enabled_boot_interfaces pxe,ipxe,fake
 crudini --set /etc/ironic/ironic.conf DEFAULT enabled_power_interfaces ipmitool,idrac,fake
@@ -42,12 +42,20 @@ crudini --set /etc/ironic/ironic.conf pxe tftp_master_path /shared/tftpboot
 crudini --set /etc/ironic/ironic.conf pxe instance_master_path /shared/html/master_images
 crudini --set /etc/ironic/ironic.conf pxe images_path /shared/html/tmp
 crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
+crudini --set /etc/ironic/ironic.conf agent deploy_logs_collect always
+crudini --set /etc/ironic/ironic.conf agent deploy_logs_local_path /shared/log/ironic/deploy
 
 ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
 
 mkdir -p /shared/html
-/usr/bin/python2 /usr/bin/ironic-conductor > /var/log/ironic-conductor.out 2>&1 &
-/usr/bin/python2 /usr/bin/ironic-api > /var/log/ironic-api.out 2>&1 &
+
+# Remove log files from last deployment
+rm -rf /shared/log/ironic
+
+mkdir -p /shared/log/ironic
+
+/usr/bin/python2 /usr/bin/ironic-conductor --log-file /shared/log/ironic/ironic-conductor.log &
+/usr/bin/python2 /usr/bin/ironic-api --log-file  /shared/log/ironic/ironic-api.log & 
 
 /bin/runhealthcheck "ironic" &>/dev/null &
 

--- a/runmariadb.sh
+++ b/runmariadb.sh
@@ -8,10 +8,18 @@ if [ ! -d "$DATADIR/mysql" ]; then
     crudini --set /etc/my.conf mysqld max_heap_table_size 1M
     crudini --set /etc/my.conf mysqld innodb_buffer_pool_size 5M
     crudini --set /etc/my.conf mysqld innodb_log_buffer_size 512K
+    crudini --set /etc/my.cnf.d/mariadb-server.cnf mysqld general_log_file /shared/log/mariadb/mariadb.log 
 
     mysql_install_db --datadir="$DATADIR"
 
-    chown -R mysql /var/log/mariadb
+    mkdir -p /shared/log/mariadb
+    touch /shared/log/mariadb/mariadb.log
+    chmod 664 /shared/log/mariadb/mariadb.log
+    chown -R mysql /shared/log/mariadb
+
+    sed -i 's/var\/log\/mariadb\/mariadb\.log/shared\/log\/mariadb\/mariadb\.log/g' \
+          /etc/my.cnf.d/mariadb-server.cnf 
+
     chown -R mysql "$DATADIR"
 
     cat > /tmp/configure-mysql.sql <<-EOSQL


### PR DESCRIPTION
Store the logs from the Ironic containers in shared area to facilitate log rollup.
This also enables storing of the ironic python agent deploy logs from each node's
deployment.