### PR TITLE
Limit api workers to 12

### DIFF
--- a/runironic.sh
+++ b/runironic.sh
@@ -5,6 +5,9 @@ IP=${IP:-"172.22.0.1"}
 HTTP_PORT=${HTTP_PORT:-"80"}
 INTERFACE=${INTERFACE:-"provisioning"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
+NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
+NUMWORKERS=$(( NUMPROC < 12 ? NUMPROC : 12 ))
+
 
 # Allow access to Ironic
 if ! iptables -C INPUT -i $INTERFACE -p tcp -m tcp --dport 6385 -j ACCEPT > /dev/null 2>&1; then
@@ -42,6 +45,7 @@ crudini --set /etc/ironic/ironic.conf pxe tftp_master_path /shared/tftpboot
 crudini --set /etc/ironic/ironic.conf pxe instance_master_path /shared/html/master_images
 crudini --set /etc/ironic/ironic.conf pxe images_path /shared/html/tmp
 crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
+crudini --set /etc/ironic/ironic.conf api api_workers ${NUMWORKERS}
 
 ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
 


### PR DESCRIPTION
Testing indicates this is a reasonable maximum, and avoids launching $many
workers on boxes with many CPU cores.

This closes https://github.com/openshift-metalkube/dev-scripts/issues/211