### PR TITLE
Fix mariadb conf file location

### DIFF
--- a/runmariadb.sh
+++ b/runmariadb.sh
@@ -2,12 +2,13 @@
 PATH=$PATH:/usr/sbin/
 DATADIR="/var/lib/mysql"
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
+MARIADB_CONF_FILE="/etc/my.cnf.d/mariadb-server.cnf"
 
-if [ ! -d "$DATADIR/mysql" ]; then
-    crudini --set /etc/my.conf mysqld max_connects 64
-    crudini --set /etc/my.conf mysqld max_heap_table_size 1M
-    crudini --set /etc/my.conf mysqld innodb_buffer_pool_size 5M
-    crudini --set /etc/my.conf mysqld innodb_log_buffer_size 512K
+if [ ! -d "${DATADIR}/mysql" ]; then
+    crudini --set "$MARIADB_CONF_FILE" mysqld max_connects 64
+    crudini --set "$MARIADB_CONF_FILE" mysqld max_heap_table_size 1M
+    crudini --set "$MARIADB_CONF_FILE" mysqld innodb_buffer_pool_size 5M
+    crudini --set "$MARIADB_CONF_FILE" mysqld innodb_log_buffer_size 512K
 
     mysql_install_db --datadir="$DATADIR"
 


### PR DESCRIPTION
Fixing location for the default mariadb conf file and adding variable to set it up.

Fixes #37 