### PR TITLE
Add iptables rules in dnsmasq

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -19,6 +19,13 @@ for iface in $( echo $EXCEPT_INTERFACE | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=$iface" /etc/dnsmasq.conf
 done
 
+# Allow access to dhcp and tftp server for pxeboot
+for port in 67 69 ; do
+    if ! iptables -C INPUT -i $INTERFACE -p udp --dport $port -j ACCEPT 2>/dev/null ; then
+        iptables -I INPUT -i $INTERFACE -p udp --dport $port -j ACCEPT
+    fi
+done
+
 /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf 2>&1 | tee /shared/log/dnsmasq/dnsmasq.log &
 /bin/runhealthcheck "dnsmasq" &>/dev/null &
 sleep infinity


### PR DESCRIPTION
This is consistent with how iptables rules are added in other containers and
will allow these sets to be removed from external scripts.